### PR TITLE
Use PACKAGE_TOP or EPICS_PACKAGE_TOP to find CPSW instead of absolute path

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+R1.4.1        Jan-13-2025    Jeremy Lorelli
+              - Adjustments to work in S3DF environment
+              - Update to CPSW R4.5.2
+
 R1.4.0        Sep-21-2020    Kukhee Kim
               - add correctionGain for upConverter
 

--- a/src/makefile
+++ b/src/makefile
@@ -1,12 +1,14 @@
 ifeq ($(PACKAGE_TOP),)
 ifneq ($(EPICS_PACKAGE_TOP),)
-	PACKAGE_TOP=$(EPICS_PACKAGE_TOP)
+PACKAGE_TOP=$(EPICS_PACKAGE_TOP)
 else
-	$(error PACKAGE_TOP or EPICS_PACKAGE_TOP must be provided in the environment or on the command line)
+$(error PACKAGE_TOP or EPICS_PACKAGE_TOP must be provided in the environment or on the command line)
 endif
 endif
 
-CPSW_DIR=$(PACKAGE_TOP)/cpsw/framework/R4.4.1/src
+CPSW_FRAMEWORK_VERSION=R4.5.2
+
+CPSW_DIR=$(PACKAGE_TOP)/cpsw/framework/$(CPSW_FRAMEWORK_VERSION)/src
 
 CCACHE_DISABLE=1
 

--- a/src/makefile
+++ b/src/makefile
@@ -1,4 +1,12 @@
-CPSW_DIR=/afs/slac/g/lcls/package/cpsw/framework/R4.4.1/src
+ifeq ($(PACKAGE_TOP),)
+ifneq ($(EPICS_PACKAGE_TOP),)
+	PACKAGE_TOP=$(EPICS_PACKAGE_TOP)
+else
+	$(error PACKAGE_TOP or EPICS_PACKAGE_TOP must be provided in the environment or on the command line)
+endif
+endif
+
+CPSW_DIR=$(PACKAGE_TOP)/cpsw/framework/R4.4.1/src
 
 CCACHE_DISABLE=1
 


### PR DESCRIPTION
This is a fix for building in the s3df environment